### PR TITLE
Always respect overscanCount regardless of scroll direction

### DIFF
--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -506,14 +506,8 @@ export default function createListComponent({
 
       // Overscan by one item in each direction so that tab/focus works.
       // If there isn't at least one extra item, tab loops back around.
-      const overscanBackward =
-        !isScrolling || scrollDirection === 'backward'
-          ? Math.max(1, overscanCount)
-          : 1;
-      const overscanForward =
-        !isScrolling || scrollDirection === 'forward'
-          ? Math.max(1, overscanCount)
-          : 1;
+      const overscanBackward = Math.max(1, overscanCount);
+      const overscanForward = Math.max(1, overscanCount);
 
       return [
         Math.max(0, startIndex - overscanBackward),


### PR DESCRIPTION
YT: https://scalyr.myjetbrains.com/youtrack/issue/FRONT-5021

- In `bvaughn/react-window`, the `overscanCount` prop is specifically used to
 prevent flickering in the direction being scrolled. In `scalyr/react-window`, we
 always respect this prop. This allows us to keep a few extra rows in the DOM,
 so that users do not unexpectedly have their text selections lost when scrolling
 only a few rows up or down.